### PR TITLE
Update CI workflows, .gitignore, and renovate configuration

### DIFF
--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Helm unittest CI
 
 on: [push]
 

--- a/.github/workflows/renovate-update-crds.yaml
+++ b/.github/workflows/renovate-update-crds.yaml
@@ -1,0 +1,34 @@
+name: Helm update CRDs CI
+
+on:
+  push:
+    branches:
+      - renovate/*
+permissions:
+  contents: write
+
+jobs:
+  update-crds:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.3.0
+        with:
+          version: v3.16.3
+      - name: Update CRDs
+        run: ./update-crds.sh
+      - name: Commit changes in crds
+        if: ${{ !env.ACT }}
+        run: |
+          if ! git diff --exit-code templates/*-crd.yaml > /dev/null; then 
+            git add templates/*-crd.yaml
+            git config --global user.name 'Mr. Robot'
+            git config --global user.email 'robot@users.noreply.github.com'
+            git commit -m "Automated crds update after helm chart update"
+            git push
+          fi
+      - name: Local commit report
+        if: ${{ env.ACT }}
+        run: |
+          git status

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
-/.project
-/_local/
+local-ca.*
+.vscode
+*.swp
+.project
+_local
+tests/__snapshot__/
+/test-output.xml

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":dependencyDashboard"
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
This pull request includes changes to improve the CI workflows and update the Renovate configuration. The most important changes include the addition of a new workflow for updating CRDs and modifications to existing workflows and configurations.

Improvements to CI workflows:

* [`.github/workflows/helm-unittest.yaml`](diffhunk://#diff-dd184113118a7e45df053335c3b67aed9d54b00ccdff095d429b188ee387dc7dL1-R1): Renamed the workflow to "Helm unittest CI" for better clarity.
* [`.github/workflows/renovate-update-crds.yaml`](diffhunk://#diff-39c4a4e95034e8d56aca1b09d0cdbbc98f4b3c28313f15d54c23f5382fcc3a54R1-R34): Added a new workflow to automate the update of CRDs when changes are pushed to branches matching the pattern `renovate/*`. This workflow sets up Helm, runs a script to update CRDs, and commits the changes if any updates are detected.

Configuration updates:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L4-R4): Changed the Renovate configuration to extend from "config:recommended" instead of "config:base" for better default settings.