### PR TITLE
Enable automerge for patch updates and GitHub Actions in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,34 @@
     "config:recommended",
     ":dependencyDashboard"
   ],
+  "packageRules": [
+    {
+      "automerge": true,
+      "automergeStrategy": "squash",
+      "matchPackageNames": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "automerge": true,
+      "automergeStrategy": "squash",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "digest",
+        "major",
+        "minor",
+        "patch"
+      ]
+    }
+  ],
   "postUpdateOptions": [
     "helmUpdateSubChartArchives"
   ]


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to automate merging of certain dependency updates. The main change is the addition of new `packageRules` to streamline dependency management.

Dependency update automation:

* Added a `packageRules` entry to automatically merge all patch updates for any package using the squash strategy.
* Added a `packageRules` entry to automatically merge all updates (digest, major, minor, patch) for `github-actions` managed dependencies, also using the squash strategy.